### PR TITLE
Add JWT service to secure services

### DIFF
--- a/server/controllers/auth.go
+++ b/server/controllers/auth.go
@@ -1,0 +1,46 @@
+package controllers
+
+import (
+	"net/http"
+
+	model "github.com/fuenrob/server-go/models"
+	"github.com/labstack/echo"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+func Login(db *gorm.DB) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		email := c.FormValue("email")
+		password := []byte(c.FormValue("password"))
+		hashedPassword, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
+
+		if err != nil {
+			return c.JSON(http.StatusConflict, echo.Map{
+				"error":        true,
+				"token":        "",
+				"errorMessage": "Problema al encriptar la contraseña",
+			})
+		}
+
+		var user model.User
+		exist := db.Where("email = ?", email).First(&user)
+
+		if exist.Error != nil {
+			return echo.ErrUnauthorized
+		}
+
+		errMatch := bcrypt.CompareHashAndPassword(hashedPassword, password)
+
+		if errMatch != nil {
+			return echo.ErrUnauthorized
+		}
+
+		token := model.GenerateUserToken(email)
+
+		return c.JSON(http.StatusOK, echo.Map{
+			"error": false,
+			"token": token,
+		})
+	}
+}

--- a/server/controllers/auth.go
+++ b/server/controllers/auth.go
@@ -5,34 +5,15 @@ import (
 
 	model "github.com/fuenrob/server-go/models"
 	"github.com/labstack/echo"
-	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
 func Login(db *gorm.DB) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		email := c.FormValue("email")
-		password := []byte(c.FormValue("password"))
-		hashedPassword, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
+		password := c.FormValue("password")
 
-		if err != nil {
-			return c.JSON(http.StatusConflict, echo.Map{
-				"error":        true,
-				"token":        "",
-				"errorMessage": "Problema al encriptar la contraseña",
-			})
-		}
-
-		var user model.User
-		exist := db.Where("email = ?", email).First(&user)
-
-		if exist.Error != nil {
-			return echo.ErrUnauthorized
-		}
-
-		errMatch := bcrypt.CompareHashAndPassword(hashedPassword, password)
-
-		if errMatch != nil {
+		if !model.VerifyLogin(db, email, password) {
 			return echo.ErrUnauthorized
 		}
 

--- a/server/controllers/auth.go
+++ b/server/controllers/auth.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	model "github.com/fuenrob/server-go/models"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 

--- a/server/controllers/user.go
+++ b/server/controllers/user.go
@@ -40,7 +40,10 @@ func GetUserById(db *gorm.DB) func(c echo.Context) error {
 func CreateNewUser(db *gorm.DB) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		name := c.FormValue("name")
-		user := &model.User{Name: name}
+		email := c.FormValue("email")
+		password := c.FormValue("password")
+
+		user := &model.User{Name: name, Email: email, Password: password}
 
 		result := db.Create(&user)
 
@@ -56,6 +59,9 @@ func UpdateUserById(db *gorm.DB) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		id := c.Param("id")
 		name := c.FormValue("name")
+		email := c.FormValue("email")
+		password := c.FormValue("password")
+
 		var user model.User
 
 		resultGet := db.First(&user, id)
@@ -65,6 +71,8 @@ func UpdateUserById(db *gorm.DB) func(c echo.Context) error {
 		}
 
 		user.Name = name
+		user.Email = email
+		user.Password = password
 
 		resultSave := db.Save(&user)
 

--- a/server/controllers/user.go
+++ b/server/controllers/user.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	model "github.com/fuenrob/server-go/models"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -13,14 +13,14 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/labstack/gommon v0.3.1 // indirect
+	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
-	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
-	golang.org/x/net v0.0.0-20220923203811-8be639271d50 // indirect
-	golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 // indirect
+	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b
+	golang.org/x/net v0.0.0-20221004154528-8021a29435af // indirect
+	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 	golang.org/x/text v0.3.7 // indirect
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/echo v3.3.10+incompatible

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,12 +7,15 @@ require (
 	gorm.io/gorm v1.23.10
 )
 
+require golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
+
 require (
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/echo/v4 v4.9.0
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -12,6 +12,8 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/echo/v4 v4.9.0 h1:wPOF1CE6gvt/kmbMR4dGzWvHMPT+sAEUJOwOTtvITVY=
+github.com/labstack/echo/v4 v4.9.0/go.mod h1:xkCDAdFCIf8jsFQ5NnbK7oqaF/yU1A1X20Ltm0OvSks=
 github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=
 github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8=
@@ -51,6 +53,8 @@ golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow
 golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 h1:Hir2P/De0WpUhtrKGGjvSb2YxUgyZ7EFOSLIcSSpiwE=
+golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/server/go.sum
+++ b/server/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
@@ -31,12 +33,16 @@ golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCzt
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20220923203811-8be639271d50 h1:vKyz8L3zkd+xrMeIaBsQ/MNVPVFSffdaU3ZyYlBGFnI=
 golang.org/x/net v0.0.0-20220923203811-8be639271d50/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221002022538-bcab6841153b h1:6e93nYa3hNqAvLr0pD4PN1fFS+gKzp2zAXqrnTCstqU=
+golang.org/x/net v0.0.0-20221002022538-bcab6841153b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 h1:nwzwVf0l2Y/lkov/+IYgMMbFyI+QypZDds9RxlSmsFQ=
 golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/server/go.sum
+++ b/server/go.sum
@@ -14,6 +14,8 @@ github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/gommon v0.3.1 h1:OomWaJXm7xR6L1HmEtGyQf26TEn7V6X88mktX9kee9o=
 github.com/labstack/gommon v0.3.1/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
+github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8=
+github.com/labstack/gommon v0.4.0/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -31,10 +33,14 @@ github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20220923203811-8be639271d50 h1:vKyz8L3zkd+xrMeIaBsQ/MNVPVFSffdaU3ZyYlBGFnI=
 golang.org/x/net v0.0.0-20220923203811-8be639271d50/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20221002022538-bcab6841153b h1:6e93nYa3hNqAvLr0pD4PN1fFS+gKzp2zAXqrnTCstqU=
 golang.org/x/net v0.0.0-20221002022538-bcab6841153b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/server/main.go
+++ b/server/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	controllers "github.com/fuenrob/server-go/controllers"
+	model "github.com/fuenrob/server-go/models"
 	utils "github.com/fuenrob/server-go/utils"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
+	middleware "github.com/labstack/echo/v4/middleware"
 )
 
 func main() {
@@ -12,13 +14,21 @@ func main() {
 
 	e := echo.New()
 
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+
 	e.POST("/login", controllers.Login(db))
 
-	e.GET("/users", controllers.GetAllUsers(db))
-	e.GET("/users/:id", controllers.GetUserById(db))
+	r := e.Group("/admin")
+
+	// Configure middleware with the custom claims type
+	r.Use(middleware.JWTWithConfig(model.GetConfigJWT()))
+
+	r.GET("/users", controllers.GetAllUsers(db))
+	r.GET("/users/:id", controllers.GetUserById(db))
 	e.POST("/users", controllers.CreateNewUser(db))
-	e.PUT("/users/:id", controllers.UpdateUserById(db))
-	e.DELETE("/users/:id", controllers.DeleteUserById(db))
+	r.PUT("/users/:id", controllers.UpdateUserById(db))
+	r.DELETE("/users/:id", controllers.DeleteUserById(db))
 
 	e.Logger.Fatal(e.Start(":9999"))
 }

--- a/server/main.go
+++ b/server/main.go
@@ -12,6 +12,8 @@ func main() {
 
 	e := echo.New()
 
+	e.POST("/login", controllers.Login(db))
+
 	e.GET("/users", controllers.GetAllUsers(db))
 	e.GET("/users/:id", controllers.GetUserById(db))
 	e.POST("/users", controllers.CreateNewUser(db))

--- a/server/models/jwt.go
+++ b/server/models/jwt.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+type jwtCustomClaims struct {
+	Name  string `json:"name"`
+	Admin bool   `json:"admin"`
+	jwt.StandardClaims
+}
+
+func GenerateUserToken(name string) string {
+	// Set custom claims
+	claims := &jwtCustomClaims{
+		name,
+		true,
+		jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour * 72).Unix(),
+		},
+	}
+
+	// Create token with claims
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	// Generate encoded token and send it as response.
+	userToken, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		return err.Error()
+	}
+
+	return userToken
+}

--- a/server/models/jwt.go
+++ b/server/models/jwt.go
@@ -4,12 +4,22 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt"
+	middleware "github.com/labstack/echo/v4/middleware"
 )
 
 type jwtCustomClaims struct {
 	Name  string `json:"name"`
 	Admin bool   `json:"admin"`
 	jwt.StandardClaims
+}
+
+func GetConfigJWT() middleware.JWTConfig {
+	config := middleware.JWTConfig{
+		Claims:     &jwtCustomClaims{},
+		SigningKey: []byte("secret"),
+	}
+
+	return config
 }
 
 func GenerateUserToken(name string) string {

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -13,10 +13,32 @@ type User struct {
 }
 
 func (user *User) BeforeSave(db *gorm.DB) (err error) {
-	password := []byte(user.Password)
-	if hashedPassword, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost); err == nil {
+	if hashedPassword, err := HashPassword(user.Password); err == nil {
 		db.Statement.SetColumn("Password", hashedPassword)
 	}
 
 	return err
+}
+
+func HashPassword(password string) (string, error) {
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(bytes), err
+}
+
+func CheckPasswordHash(hash, password string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
+}
+
+func VerifyLogin(db *gorm.DB, username, password string) bool {
+	hashedPassword, _ := HashPassword(password)
+
+	var user User
+	exist := db.Where("email = ?", username).First(&user)
+
+	if exist.Error != nil {
+		return false
+	}
+
+	return CheckPasswordHash(hashedPassword, password)
 }

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -1,10 +1,22 @@
 package model
 
 import (
+	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
 type User struct {
 	gorm.Model
-	Name string
+	Name     string
+	Email    string
+	Password string
+}
+
+func (user *User) BeforeSave(db *gorm.DB) (err error) {
+	password := []byte(user.Password)
+	if hashedPassword, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost); err == nil {
+		db.Statement.SetColumn("Password", hashedPassword)
+	}
+
+	return err
 }


### PR DESCRIPTION
JWT (Json Web Token) technology is used to control access to services:
- See all users
- View data of a user
- Edit user data
- Delete user

In addition, a new service is added to login and two fields to the structure (database model):
- email
- password

These are the fields used to login with the service:
```
curl -X POST -d 'email=email' -d 'password=password' localhost:9999/login
```

For services that require a token, the token must be added to the service request:
```
curl localhost:9999/admin/users -H "Authorization: Bearer TOKEN"
```